### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ composer require marcusmyers/laravel-dashboard-accuweather-tile
 
 ## Usage
 
+In the `dashboard` config file, you must add this configuration in the `tiles` key.
+
+Sign up at https://developer.accuweather.com/ to obtain `ACCUWEAHTER_API_KEY` and you can find your location key by searching for you city at https://www.accuweather.com.  The resulting url should have your location key, i.e. https://www.accuweather.com/en/us/chicago/60608/weather-forecast/348308, the Chicago location key is 348308. AccuWeather only allows you 50 API request a day for a free account.
+
+```php
+// in config/dashboard.php
+
+return [
+    // ...
+    'tiles' => [
+        'accuweather' => [
+            'location_key' => '12345',
+            'api_key' => env('ACCUWEATHER_API_KEY'),
+        ]
+    ],
+];
+```
+
+In `app\Console\Kernel.php` you should schedule the `MarcusMyers\AccuWeatherTile\Commands\FetchAccuWeatherCurrentConditionsCommand` to run every hour.
+
+If you want to use the forecast you can optionally schedule the `MarcusMyers\AccuWeatherTile\Commands\FetchAccuWeatherFiveDayForecastCommand` to run daily.
+
+```php
+// in app/console/Kernel.php
+
+protected function schedule(Schedule $schedule)
+{
+    // ...
+    $schedule->command(MarcusMyers\AccuWeatherTile\Commands\FetchAccuWeatherCurrentConditionsCommand::class)->hourly();
+    $schedule->command(MarcusMyers\AccuWeatherTile\Commands\FetchAccuWeatherFiveDayForecastCommand::class)->daily();
+}
+```
+
 In your dashboard view you can use the `livewire:accuweather-current-conditions-tile` component or the `livewire:accuweather-five-day-forecast-tile`.
 
 ```html


### PR DESCRIPTION
The readme was missing some very important information on setting up AccuWeather API key and the config. This commit adds the correct usage information now.