### PR TITLE
load view data on render

### DIFF
--- a/src/Components/AccuWeatherCurrentConditionsComponent.php
+++ b/src/Components/AccuWeatherCurrentConditionsComponent.php
@@ -10,18 +10,17 @@ class AccuWeatherCurrentConditionsComponent extends Component
 {
     /** @var string */
     public $position;
-    public $weatherConditions;
 
     public function mount(string $position)
     {
         $this->position = $position;
-        $this->weatherConditions = AccuWeatherStore::make()->currentConditions();
     }
 
     public function render()
     {
         return view('dashboard-accuweather-tiles::current-conditions.tile', [
           'refreshIntervalInSeconds' => config('dashboard.tiles.accuweather.refresh_interval_in_seconds') ?? 60,
+          'weatherConditions' => AccuWeatherStore::make()->currentConditions()
         ]);
     }
 }

--- a/src/Components/AccuWeatherFiveDayForecastComponent.php
+++ b/src/Components/AccuWeatherFiveDayForecastComponent.php
@@ -10,18 +10,17 @@ class AccuWeatherFiveDayForecastComponent extends Component
 {
     /** @var string */
     public $position;
-    public $forecasts;
 
     public function mount(string $position)
     {
         $this->position = $position;
-        $this->forecasts = AccuWeatherStore::make()->forecasts();
     }
 
     public function render()
     {
         return view('dashboard-accuweather-tiles::five-day-forecast.tile', [
           'refreshIntervalInSeconds' => config('dashboard.tiles.accuweather.refresh_interval_in_seconds') ?? 60,
+          'forecasts' => AccuWeatherStore::make()->forecasts(),
         ]);
     }
 }


### PR DESCRIPTION
I noticed, the tiles won't get updated after funning the fetch commands.

This is because mount will only get hit once the page is loaded. For updates in connection with polling, the data needs to be loaded on render (https://laravel-livewire.com/docs/lifecycle-hooks).